### PR TITLE
hook: add support for fcntl() function. resolves #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+sudo: false
+
+os: linux
+
+language: c
+
+compiler:
+  - gcc
+  - clang
+
+addons:
+  apt:
+    packages: [ python ]
+
+cache:
+  apt: true
+
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-COPTS=-O -g -Wall -Werror -std=gnu99
+COPTS=-O -g -Wall -Werror -std=gnu99 -Wl,--no-as-needed -lrt
 ifneq ($(MAKECMDGOALS),test)
 	COPTS+= -DNDEBUG
 endif

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,12 @@ test: all $(ALL_TESTS)
 	|| exit 1; \
 	python ./t/echo_server.py ./t/runner $(VALGRIND) \
 	&& echo "Test case 003-disabled.c passed" || exit 1;
+	# 004
+	export $(TESTENV); \
+	$(CC) $(COPTS) -o ./t/runner ./t/004-setnonblocking.c ./t/runner.c ./t/test_case.c \
+	|| exit 1; \
+	MOCKEAGAIN=w python ./t/echo_server.py ./t/runner $(VALGRIND) \
+	&& echo "Test case 004-setnonblocking.c passed" || exit 1;
 
 clean:
 	rm -rf *.so *.o *.lo t/runner

--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ documentation](https://github.com/openresty/mockeagain).
 process. This does not causes issue when using with `nginx` as each `nginx`
 worker maintains only one `epoll` instance.
 * Mocking is only active on non blocking stream sockets. The way `mockeagain++`
-detects this condition is by hooking `accept4()`, `socket()` and `ioctl()`
-system calls and try to interpret state of the file descriptor by observing.
-`fcntl()` is currently not implemented due to the complexity involved in
-hooking it (different sizes of third argument). `nginx` does not uses
-`fcntl()`.
+detects this condition is by hooking `accept4()`, `socket()`, `ioctl()` and
+`fcntl()` system calls and try to interpret state of the file descriptor by
+observing.
 
 ## Copyright & License
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # mockeagain++
 
+[![Build Status](https://travis-ci.org/dndx/mockeagainxx.svg?branch=master)](https://travis-ci.org/dndx/mockeagainxx)
+
 This library was inspired by [agentzh](https://github.com/agentzh)'s
 [mockeagain](https://github.com/openresty/mockeagain). It does everything
 mockeagain does plus the following:

--- a/t/004-setnonblocking.c
+++ b/t/004-setnonblocking.c
@@ -1,0 +1,36 @@
+#include <sys/ioctl.h>
+#include <fcntl.h>
+#include "test_case.h"
+
+int run_test(int fd) {
+    int n;
+    const char  *buf = "test";
+    const int    len = sizeof("test") - 1;
+    int           nb = 0;
+
+    /* first make it blocking */
+    assert(!ioctl(fd, FIONBIO, &nb));
+
+    n = send(fd, buf, len, 0);
+    assert(n == len);
+
+    /* make it nb again */
+    nb = 1;
+    assert(!ioctl(fd, FIONBIO, &nb));
+
+    n = send(fd, buf, len, 0);
+    assert(n == 1);
+
+    /* blocking using fcntl */
+    assert(!fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) & ~O_NONBLOCK));
+
+    n = send(fd, buf, len, 0);
+    assert(n == len);
+
+    /* nb using fcntl */
+    assert(!fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK));
+    n = send(fd, buf, len, 0);
+    assert(n == 1);
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Initial support for `fcntl()` hooking.